### PR TITLE
Change step to TypeList to ensure ordering

### DIFF
--- a/teamcity/resource_feature_commit_status_publisher.go
+++ b/teamcity/resource_feature_commit_status_publisher.go
@@ -162,7 +162,7 @@ func buildGithubCommitStatusPublisher(d *schema.ResourceData) (api.BuildFeature,
 		opt = api.NewCommitStatusPublisherGithubOptionsPassword(host, local["username"].(string), local["password"].(string))
 	}
 
-	return api.NewFeatureCommitStatusPublisherGithub(opt)
+	return api.NewFeatureCommitStatusPublisherGithub(opt, "")
 }
 
 func getBuildFeatureCommitPublisher(c *api.BuildFeatureService, id string) (*api.FeatureCommitStatusPublisher, error) {

--- a/teamcity/resource_vcs_root_git_test.go
+++ b/teamcity/resource_vcs_root_git_test.go
@@ -257,7 +257,7 @@ func testAccVcsRootGitConfig(projectId string) string {
 resource "teamcity_vcs_root_git" "git_test" {
 	name = "application"
 	project_id = "%s"
-	fetch_url = "https://github.com/kelseyhightower/nocode"
+	fetch_url = "https://github.com/cvbarros/terraform-provider-teamcity"
 	default_branch = "refs/head/master"
 }
 `, projectId)


### PR DESCRIPTION
After merging the upstream branch to keep the order of the build steps
intact, a few things needed to be ironed out in order to run the tests.

The default values were also adjusted to match the SDK, and ensure
idempotency of the resources.

Drive-by:
* Fix-makefile