### PR TITLE
Fix idempotency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,14 @@
-# OSX
-.DS_Store
-
-# Binaries for programs and plugins
-*.exe
 *.dll
-*.so
 *.dylib
-
-# Test binary, build with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
+*.exe
 *.out
-
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+*.so
+*.test
+.DS_Store
 .glide/
-
-# VSCode
-.vscode/
-
-#TeamCity docker mounts
-log_dir/
-data_dir/
-
-#Terraform
 .terraform/
-
-#Local Testing environment
 .test.env
+.vscode/
+data_dir/
+dist/
+log_dir/

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
 
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/cvbarros/go-teamcity-sdk"
+  branch = "ss-master"
+  name = "github.com/shipstation/go-teamcity-sdk"
 
 [[constraint]]
   name = "github.com/hashicorp/terraform"

--- a/teamcity/resource_build_config_test.go
+++ b/teamcity/resource_build_config_test.go
@@ -731,6 +731,26 @@ func testAccCheckProperties(
 	}
 }
 
+func TestAccBuildConfig_StepsOctopusPushPackage(t *testing.T) {
+	var bc api.BuildType
+	resName := "teamcity_build_config.build_configuration_test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBuildConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccBuildConfigOctopusPushPackage,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBuildConfigExists(resName, &bc),
+					resource.TestCheckResourceAttrSet(resName, "step.0.step_id"),
+				),
+			},
+		},
+	})
+}
+
 const TestAccBuildConfigBasic = `
 resource "teamcity_project" "build_config_project_test" {
   name = "build_config_project_test"
@@ -938,6 +958,27 @@ resource "teamcity_build_config" "build_configuration_test" {
 		name = "updated_script"
 		file = "updated.ps1"
 		args = "-Target pullrequest"
+	}
+}
+`
+
+const TestAccBuildConfigOctopusPushPackage = `
+resource "teamcity_project" "build_config_project_test" {
+  name = "build_config_project_test"
+}
+
+resource "teamcity_build_config" "build_configuration_test" {
+	name = "build config test"
+	project_id = "${teamcity_project.build_config_project_test.id}"
+
+	step {
+		name		  = "Octopus Push Package"
+		type          = "octopus.push.package"
+		host          = "https://octopus.test"
+		api_key       = "AK37CJDBC6"
+		package_paths = "*"
+		force_push    = true
+		additional_command_line_arguments = "--releasenotes notes"
 	}
 }
 `


### PR DESCRIPTION
Ensures the provider is idempotent (i.e. a `terraform plan` running
after `terraform apply` must be empty).

• Update Makefile
  • Increase test time out
  • Enable `rest.listSecureProperties` option
• Add integration tests
• Fix `additional_command_line_arguments` option
• Remove dead code
• Use ShipStation's version of the TeamCIty SDK by default
• Mark the API as sensitive information

Fixes #DEVOPS-2848